### PR TITLE
Add Perro entity across layers

### DIFF
--- a/AbogadosLatam.Application/Contracts/Interfases/Persistence/Perro/IPerroCommandRepository.cs
+++ b/AbogadosLatam.Application/Contracts/Interfases/Persistence/Perro/IPerroCommandRepository.cs
@@ -1,0 +1,8 @@
+using AbogadosLatam.Application.Contracts.Persistence;
+using AbogadosLatam.Domain;
+
+namespace AbogadosLatam.Application.Contracts;
+
+public interface IPerroCommandRepository : ICommandRepository<Perro>
+{
+}

--- a/AbogadosLatam.Application/Contracts/Interfases/Persistence/Perro/IPerroQueryRepository.cs
+++ b/AbogadosLatam.Application/Contracts/Interfases/Persistence/Perro/IPerroQueryRepository.cs
@@ -1,0 +1,8 @@
+using AbogadosLatam.Application.Contracts.Persistence;
+using AbogadosLatam.Domain;
+
+namespace AbogadosLatam.Application.Contracts;
+
+public interface IPerroQueryRepository : IQueryRepository<Perro>
+{
+}

--- a/AbogadosLatam.Application/DTO/PerroDto.cs
+++ b/AbogadosLatam.Application/DTO/PerroDto.cs
@@ -1,0 +1,7 @@
+namespace AbogadosLatam.Application.Features.DTO;
+
+public class PerroDto
+{
+    public int Id { get; set; }
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/AbogadosLatam.Application/UseCases/Perro/Create/CreatePerroCommand.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/Create/CreatePerroCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class CreatePerroCommand : IRequest<int>
+{
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/AbogadosLatam.Application/UseCases/Perro/Create/CreatePerroCommandHandler.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/Create/CreatePerroCommandHandler.cs
@@ -1,0 +1,24 @@
+using AbogadosLatam.Application.Contracts;
+using AutoMapper;
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class CreatePerroCommandHandler : IRequestHandler<CreatePerroCommand, int>
+{
+    private readonly IPerroCommandRepository _perroRepository;
+    private readonly IMapper _mapper;
+
+    public CreatePerroCommandHandler(IPerroCommandRepository perroRepository, IMapper mapper)
+    {
+        _perroRepository = perroRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<int> Handle(CreatePerroCommand request, CancellationToken cancellationToken)
+    {
+        var perro = _mapper.Map<Domain.Perro>(request);
+        await _perroRepository.CreateAsync(perro);
+        return perro.Id;
+    }
+}

--- a/AbogadosLatam.Application/UseCases/Perro/Delete/DeletePerroCommand.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/Delete/DeletePerroCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class DeletePerroCommand : IRequest<Unit>
+{
+    public int Id { get; set; }
+}

--- a/AbogadosLatam.Application/UseCases/Perro/Delete/DeletePerroCommandHandler.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/Delete/DeletePerroCommandHandler.cs
@@ -1,0 +1,29 @@
+using AbogadosLatam.Application.Contracts;
+using MediatR;
+using AbogadosLatam.Application.MappingProfiles.Exceptions;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class DeletePerroCommandHandler : IRequestHandler<DeletePerroCommand, Unit>
+{
+    private readonly IPerroCommandRepository _perroRepository;
+    private readonly IPerroQueryRepository _perroQueryRepository;
+
+    public DeletePerroCommandHandler(IPerroCommandRepository perroRepository, IPerroQueryRepository perroQueryRepository)
+    {
+        _perroRepository = perroRepository;
+        _perroQueryRepository = perroQueryRepository;
+    }
+
+    public async Task<Unit> Handle(DeletePerroCommand request, CancellationToken cancellationToken)
+    {
+        var perroToDelete = await _perroQueryRepository.GetByIdAsync(request.Id);
+
+        if (perroToDelete == null)
+            throw new NotFoundException(nameof(Perro), request.Id);
+
+        await _perroRepository.DeleteAsync(perroToDelete);
+
+        return Unit.Value;
+    }
+}

--- a/AbogadosLatam.Application/UseCases/Perro/GetAll/GetPerrosQuery.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/GetAll/GetPerrosQuery.cs
@@ -1,0 +1,8 @@
+using AbogadosLatam.Application.Features.DTO;
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class GetPerrosQuery : IRequest<List<PerroDto>>
+{
+}

--- a/AbogadosLatam.Application/UseCases/Perro/GetAll/GetPerrosQueryHandler.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/GetAll/GetPerrosQueryHandler.cs
@@ -1,0 +1,25 @@
+using AbogadosLatam.Application.Contracts;
+using AbogadosLatam.Application.Features.DTO;
+using AutoMapper;
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class GetPerrosQueryHandler : IRequestHandler<GetPerrosQuery, List<PerroDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IPerroQueryRepository _perroRepository;
+
+    public GetPerrosQueryHandler(IMapper mapper, IPerroQueryRepository perroRepository)
+    {
+        _mapper = mapper;
+        _perroRepository = perroRepository;
+    }
+
+    public async Task<List<PerroDto>> Handle(GetPerrosQuery request, CancellationToken cancellationToken)
+    {
+        var perros = await _perroRepository.GetAsync();
+        var data = _mapper.Map<List<PerroDto>>(perros);
+        return data;
+    }
+}

--- a/AbogadosLatam.Application/UseCases/Perro/GetById/GetPerroQuery.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/GetById/GetPerroQuery.cs
@@ -1,0 +1,9 @@
+using AbogadosLatam.Application.Features.DTO;
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class GetPerroQuery(int id) : IRequest<PerroDto>
+{
+    public int Id { get; set; } = id;
+}

--- a/AbogadosLatam.Application/UseCases/Perro/GetById/GetPerroQueryHandler.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/GetById/GetPerroQueryHandler.cs
@@ -1,0 +1,25 @@
+using AbogadosLatam.Application.Contracts;
+using AbogadosLatam.Application.Features.DTO;
+using AutoMapper;
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class GetPerroQueryHandler : IRequestHandler<GetPerroQuery, PerroDto>
+{
+    private readonly IMapper _mapper;
+    private readonly IPerroQueryRepository _perroRepository;
+
+    public GetPerroQueryHandler(IMapper mapper, IPerroQueryRepository perroRepository)
+    {
+        _mapper = mapper;
+        _perroRepository = perroRepository;
+    }
+
+    public async Task<PerroDto> Handle(GetPerroQuery request, CancellationToken cancellationToken)
+    {
+        var perro = await _perroRepository.GetByIdAsync(request.Id);
+        var data = _mapper.Map<PerroDto>(perro);
+        return data;
+    }
+}

--- a/AbogadosLatam.Application/UseCases/Perro/Update/UpdatePerroCommand.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/Update/UpdatePerroCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class UpdatePerroCommand : IRequest<Unit>
+{
+    public int Id { get; set; }
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/AbogadosLatam.Application/UseCases/Perro/Update/UpdatePerroCommandHandler.cs
+++ b/AbogadosLatam.Application/UseCases/Perro/Update/UpdatePerroCommandHandler.cs
@@ -1,0 +1,34 @@
+using AbogadosLatam.Application.Contracts;
+using AutoMapper;
+using MediatR;
+
+namespace AbogadosLatam.Application.Features.UseCases.Perro;
+
+public class UpdatePerroCommandHandler : IRequestHandler<UpdatePerroCommand, Unit>
+{
+    private readonly IPerroCommandRepository _perroRepository;
+    private readonly IPerroQueryRepository _perroQueryRepository;
+    private readonly IMapper _mapper;
+
+    public UpdatePerroCommandHandler(IPerroCommandRepository perroRepository, IPerroQueryRepository perroQueryRepository, IMapper mapper)
+    {
+        _perroRepository = perroRepository;
+        _perroQueryRepository = perroQueryRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<Unit> Handle(UpdatePerroCommand request, CancellationToken cancellationToken)
+    {
+        var existingPerro = await _perroQueryRepository.GetByIdAsync(request.Id);
+        if (existingPerro == null)
+        {
+            throw new KeyNotFoundException($"El perro con ID {request.Id} no existe.");
+        }
+
+        existingPerro.Nombre = request.Nombre;
+
+        await _perroRepository.UpdateAsync(existingPerro);
+
+        return Unit.Value;
+    }
+}

--- a/AbogadosLatam.DataSore.MSSQL/DataBaseContext/AbogadosLatamContext.cs
+++ b/AbogadosLatam.DataSore.MSSQL/DataBaseContext/AbogadosLatamContext.cs
@@ -20,10 +20,11 @@ public class AbogadosLatamContext : DbContext
     public DbSet<EspecialidadEntity> Especialidades { get; set; }
     public DbSet<EstudioEntity> Estudios { get; set; }
     public DbSet<SucursalEntity> Sucursales { get; set; }
-    
+
     public DbSet<EstudioEspecialidadEntity> EstudioEspecialidades { get; set; }
     public DbSet<AbogadoEntity> Abogados { get; set; }
     public DbSet<ClienteEntity> Clientes { get; set; }
+    public DbSet<PerroEntity> Perros { get; set; }
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/AbogadosLatam.DataSore.MSSQL/Model/MappingProfiles/ApplicationMappingProfile.cs
+++ b/AbogadosLatam.DataSore.MSSQL/Model/MappingProfiles/ApplicationMappingProfile.cs
@@ -1,4 +1,5 @@
 using AbogadosLatam.Domain;
+using AbogadosLatam.DataSore.MSSQL.Model;
 using AutoMapper;
 
 namespace AbogadosLatam.DataSore.MSSQL.Model.MappingProfiles;
@@ -15,6 +16,7 @@ public class ApplicationMappingProfile: Profile
         CreateMap<EstudioEspecialidad, EstudioEspecialidadEntity>().ReverseMap();
         CreateMap<Abogado, AbogadoEntity>().ReverseMap();
         CreateMap<Cliente, ClienteEntity>().ReverseMap();
+        CreateMap<Perro, PerroEntity>().ReverseMap();
 
     }
 }

--- a/AbogadosLatam.DataSore.MSSQL/Model/PerroEntity.cs
+++ b/AbogadosLatam.DataSore.MSSQL/Model/PerroEntity.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using AbogadosLatam.DataSore.MSSQL.Model.Common;
+
+namespace AbogadosLatam.DataSore.MSSQL.Model;
+
+[Table("Perros")]
+public class PerroEntity : EFEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/AbogadosLatam.DataSore.MSSQL/PersistenceServiceRegistration.cs
+++ b/AbogadosLatam.DataSore.MSSQL/PersistenceServiceRegistration.cs
@@ -9,6 +9,7 @@ using AbogadosLatam.DataSore.MSSQL.Repositories.Estudio;
 using AbogadosLatam.DataSore.MSSQL.Repositories.EstudioEspecialidad;
 using AbogadosLatam.DataSore.MSSQL.Repositories.Pais;
 using AbogadosLatam.DataSore.MSSQL.Repositories.Sucursal;
+using AbogadosLatam.DataSore.MSSQL.Repositories.Perro;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,9 +47,12 @@ public static class PersistenceServiceRegistration
 
         services.AddScoped<IAbogadoCommandRepository, AbogadoCommandRepository>();
         services.AddScoped<IAbogadoQueryRepository, AbogadoQueryRepository>();
-        
+
         services.AddScoped<IClienteCommandRepository, ClienteCommandRepository>();
         services.AddScoped<IClienteQueryRepository, ClienteQueryRepository>();
+
+        services.AddScoped<IPerroCommandRepository, PerroCommandRepository>();
+        services.AddScoped<IPerroQueryRepository, PerroQueryRepository>();
 
         return services;
 

--- a/AbogadosLatam.DataSore.MSSQL/Repositories/Perro/PerroCommandRepository.cs
+++ b/AbogadosLatam.DataSore.MSSQL/Repositories/Perro/PerroCommandRepository.cs
@@ -1,0 +1,16 @@
+using AbogadosLatam.Application.Contracts;
+using AbogadosLatam.DataSore.MSSQL.DataBaseContext;
+using AbogadosLatam.DataSore.MSSQL.Model;
+using AutoMapper;
+
+namespace AbogadosLatam.DataSore.MSSQL.Repositories.Perro;
+
+public class PerroCommandRepository : CommandRepository<Domain.Perro, PerroEntity>, IPerroCommandRepository
+{
+    private readonly IMapper _mapper;
+
+    public PerroCommandRepository(AbogadosLatamContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}

--- a/AbogadosLatam.DataSore.MSSQL/Repositories/Perro/PerroQueryRepository.cs
+++ b/AbogadosLatam.DataSore.MSSQL/Repositories/Perro/PerroQueryRepository.cs
@@ -1,0 +1,16 @@
+using AbogadosLatam.Application.Contracts;
+using AbogadosLatam.DataSore.MSSQL.DataBaseContext;
+using AbogadosLatam.DataSore.MSSQL.Model;
+using AutoMapper;
+
+namespace AbogadosLatam.DataSore.MSSQL.Repositories.Perro;
+
+public class PerroQueryRepository : QueryRepository<Domain.Perro, PerroEntity>, IPerroQueryRepository
+{
+    private readonly IMapper _mapper;
+
+    public PerroQueryRepository(AbogadosLatamContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}

--- a/AbogadosLatam.Domain/Perro.cs
+++ b/AbogadosLatam.Domain/Perro.cs
@@ -1,0 +1,8 @@
+using AbogadosLatam.Domain.Common;
+
+namespace AbogadosLatam.Domain;
+
+public class Perro : BaseEntity
+{
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/AbogadosLatam.WebAPI/Controllers/PerroController.cs
+++ b/AbogadosLatam.WebAPI/Controllers/PerroController.cs
@@ -1,0 +1,68 @@
+using AbogadosLatam.Application.Features.DTO;
+using AbogadosLatam.Application.Features.UseCases.Perro;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AbogadosLatam.WebAPI.Controllers;
+
+[Route("api/[controller]")]
+public class PerroController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public PerroController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<List<PerroDto>> Get()
+    {
+        var perros = await _mediator.Send(new GetPerrosQuery());
+        return perros;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<PerroDto>> Get(int id)
+    {
+        var perro = await _mediator.Send(new GetPerroQuery(id));
+        return Ok(perro);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Post(CreatePerroCommand perro)
+    {
+        var response = await _mediator.Send(perro);
+        return CreatedAtAction(nameof(Get), new { id = response });
+    }
+
+    [HttpPut]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Put([FromBody] UpdatePerroCommand perro)
+    {
+        if (perro.Id <= 0)
+        {
+            return BadRequest("El ID proporcionado no es válido.");
+        }
+
+        await _mediator.Send(perro);
+
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult> Delete(int id)
+    {
+        var command = new DeletePerroCommand() { Id = id };
+        await _mediator.Send(command);
+        return NoContent();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Perro` domain entity with simple `Id` and `Nombre`
- create EF model and AutoMapper profile mappings
- implement command/query repositories and register them in DI
- add application DTO and CRUD use cases via MediatR
- expose CRUD endpoints in new `PerroController`
- include DbSet for `Perro` in DbContext

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769b2d16483218639aeed8a439885